### PR TITLE
add nowplaying to getRecentTracks return type

### DIFF
--- a/src/modules/user/user.interface.ts
+++ b/src/modules/user/user.interface.ts
@@ -88,7 +88,7 @@ export interface IUserGetPersonalTags {
 
 export interface IUserGetRecentTracks {
   recenttracks: {
-    track: ITrack[];
+    track: (ITrack & { "@attr"?: { nowplaying: "true" } })[];
     "@attr": IAttr;
   };
 }


### PR DESCRIPTION
According to their [documentation](https://www.last.fm/api/show/user.getRecentTracks), getRecentTracks will also return a `nowplaying="true"` attribute if the user is currently listening to the track.

I've added this to the typings, but let me know if you'd prefer it in a different manner.